### PR TITLE
Fixing Nijigasaki Translation Errors

### DIFF
--- a/DB/LNJ_W85.json
+++ b/DB/LNJ_W85.json
@@ -469,7 +469,7 @@
         "flavor_text": "私は生徒会長として学園のみなさんのために働くことが、あなたの言葉を借りて言うのであれば『一番大好きなこと』だと考えています……",
         "ability": [
             "【A】［(2) Place 1 of your Character from Stage into Waiting Room］ When you use this card's 『ASSIST』, you may pay the cost. If you did, choose 1 opponent's Character with Level higher than opponent's Level, place it into Waiting Room.",
-            "【S】【COUNTER】 ASSIST 2500 Level 2 ［(1) Place this card from Hand into Waiting Room］ (Choose 1 of your Characters being Front Attacked, during that turn, it gets ＋2500 Power)"
+            "【S】【BACKUP】 ASSIST 2500 Level 2 ［(1) Place this card from Hand into Waiting Room］ (Choose 1 of your Characters being Front Attacked, during that turn, it gets ＋2500 Power)"
         ],
         "attributes": [
             "Music 《音楽》"
@@ -1274,7 +1274,7 @@
         "soul": 2,
         "flavor_text": "もっと自分のことを考えてほしいんだけど……\nでも、あの子の優しさに触れちゃうと、つい甘えちゃうんだよね",
         "ability": [
-            "【C】EXPERIENCE If the total Level in your Level Slot is 4 or higher, and this card is at Front Row, all your other 《音楽》 Character gets +1500 Power.",
+            "【C】EXPERIENCE If the total Level in your Level Slot is 4 or higher, and this card is at Front Row, all your 《音楽》 Characters get +1500 Power.",
             "【A】【CXCOMBO】[(1) Place 2 cards from Hand into Waiting Room] When this card is placed on Stage by 「信頼する、あなたへ」 's effect, you may pay the cost. If you did, STAND this card. (When Trigger Checks 「信頼する、あなたへ」's SWITCH effect to place this card on Stage can be activated also)"
         ],
         "attributes": [
@@ -1619,7 +1619,7 @@
         "flavor_text": "この歌、君に一番最初に聞いて欲しい。ってことで！夜中だから小声だけど、歌うね。\nねえ、もっとそばに行っていいかな？",
         "ability": [
             "【A】When you use this card's 『ASSIST』, if you have 《音楽》 Character, choose 1 of your Character in battle, during this turn, it gets +1000 Power.",
-            "【S】【COUNTER】ASSIST 2500 Level 2 ［(1) Place this card from Hand into Waiting Room］ (Choose 1 of your Characters being Front Attacked, during that turn, it gets +2500 Power)"
+            "【S】【BACKUP】ASSIST 2500 Level 2 ［(1) Place this card from Hand into Waiting Room］ (Choose 1 of your Characters being Front Attacked, during that turn, it gets +2500 Power)"
         ],
         "attributes": [
             "Music 《音楽》"
@@ -1993,7 +1993,7 @@
         "flavor_text": "なにかすごいことがあった日のことは覚えてられるけど、なんでもない日のことって忘れちゃうものでしょ？",
         "ability": [
             "【A】When you use this card's 『ASSIST』, if you have 《音楽》 Character, choose 1 of your Character in battle, during this turn, it gets +1000 Power.",
-            "【S】【COUNTER】 ASSIST 1000 Level 1 ［Place this card from Hand into Waiting Room］ (Choose 1 of your Characters being Front Attacked, during that turn, it gets ＋1000 Power)"
+            "【S】【BACKUP】 ASSIST 1000 Level 1 ［Place this card from Hand into Waiting Room］ (Choose 1 of your Characters being Front Attacked, during that turn, it gets ＋1000 Power)"
         ],
         "attributes": [
             "Music 《音楽》"
@@ -2072,7 +2072,7 @@
         "flavor_text": "まだまだ終わらせないんだから！ 勝ち逃げは無しよ！",
         "ability": [
             "【A】When you use this card's 『ASSIST』, place X cards from opponent's bottom Deck into Waiting Room. X is equal to the number of your 《音楽》 Character.",
-            "【S】【COUNTER】ASSIST 3000 Level 2 ［(1) Place this card from Hand into Waiting Room］ (Choose 1 of your Characters being Front Attacked, during that turn, it gets +3000 Power)"
+            "【S】【BACKUP】ASSIST 3000 Level 2 ［(1) Place this card from Hand into Waiting Room］ (Choose 1 of your Characters being Front Attacked, during that turn, it gets +3000 Power)"
         ],
         "attributes": [
             "Music 《音楽》"

--- a/DB/LNJ_W97.json
+++ b/DB/LNJ_W97.json
@@ -2749,7 +2749,7 @@
         ],
         "flavor_text": "",
         "ability": [
-            "[C] – All of your [妹の決断 近江 遥], this card gains +6000 Power."
+            "[C] – All of your [妹の決断 近江 遥] gain +6000 Power."
         ],
         "jpAbility": [
             "【永】 他のあなたの「妹の決断 近江 遥」すべてに、パワーを＋6000。"

--- a/DB/LNJ_W97.json
+++ b/DB/LNJ_W97.json
@@ -2718,7 +2718,7 @@
         ],
         "flavor_text": "",
         "ability": [
-            "[C] – If you have another [頑張るお姉ちゃん 近江 彼方] this card gains +6000 Power.",
+            "[C] – All of your [頑張るお姉ちゃん 近江 彼方] gain +6000 Power.",
             "[A] – When this card’s battle opponent is REVERSE, you may send that Character to Memory."
         ],
         "jpAbility": [
@@ -2749,7 +2749,7 @@
         ],
         "flavor_text": "",
         "ability": [
-            "[C] – If you have another [妹の決断 近江 遥], this card gains +6000 Power."
+            "[C] – All of your [妹の決断 近江 遥], this card gains +6000 Power."
         ],
         "jpAbility": [
             "【永】 他のあなたの「妹の決断 近江 遥」すべてに、パワーを＋6000。"


### PR DESCRIPTION
1. Characters with "COUNTER" in their text were replaced with "BACKUP", so there is no confusion between the 2 card types.

2. Kanata + Haruka wall is properly translated now.

3. Ayumu Lvl 3 is properly translated now.