### PR TITLE
Adding new LNJ cards from LL 10th Anni Premium Booster

### DIFF
--- a/DB/LL_WE39.json
+++ b/DB/LL_WE39.json
@@ -1,0 +1,180 @@
+[
+    {
+        "name": "“心をときめかせて”三船 栞子",
+        "code": "LNJ/WE39-011",
+        "rarity": "N",
+        "expansion": "Love Live! Sukufesu 10th Anniversary",
+        "side": "W",
+        "type": "Character",
+        "color": "Yellow",
+        "level": 2,
+        "cost": 1,
+        "power": 6000,
+        "trigger": [
+          "SOUL"
+        ],
+        "flavor_text": "",
+        "ability": [
+            "[C] - SUPPORT All of your level 3 or higher characters in front of this card get +2000 power.",
+            "[S] - [(2)[REST] this card] Choose one of your opponents and return it to their hand."
+        ],
+        "jpAbility": [
+            "【永】 応援 このカードの前のあなたのレベル3以上のキャラすべてに、パワーを＋2000。",
+            "【起】［(2) このカードを【レスト】する］ あなたは相手のキャラを1枚選び、手札に戻す。"
+        ],
+        "attributes": [
+            "Music"
+        ],
+        "set": "LNJ",
+        "release": "E39",
+        "sid": "011",
+        "image": "https://ws-tcg.com/wordpress/wp-content/images/cardlist/l/lnj_we39/lnj_we39_011.png"
+    },
+    {
+        "name": "まるで夢みたいです 三船 栞子",
+        "code": "LNJ/WE39-015",
+        "rarity": "N",
+        "expansion": "Love Live! Sukufesu 10th Anniversary",
+        "side": "W",
+        "type": "Character",
+        "color": "YELLOW",
+        "level": 3,
+        "cost": 2,
+        "power": 10000,
+        "trigger": [
+          "SOUL"
+        ],
+        "flavor_text": "",
+        "ability": [
+            "[A] - When this card is placed on Stage from Hand, look at up to 3 cards from the top of your deck, choose one of them to add to hand, place the rest into waiting room.",
+            "[A] - [Send two cards from hand into the waiting room] When this card attacks, you may pay the cost. If you do, deal 1 damage to your opponent. (Damage can be canceled.)"
+          ],
+        "jpAbility": [
+            "【自】 このカードが手札から舞台に置かれた時、あなたは自分の山札を上から3枚まで見て、カードを1枚まで選び、手札に加え、残りのカードを控え室に置く。",
+            "【自】［手札を2枚控え室に置く］ このカードがアタックした時、あなたはコストを払ってよい。そうしたら、相手に1ダメージを与える。（ダメージキャンセルは発生する）"
+        ],
+        "attributes": [
+            "Music"
+        ],
+        "set": "LNJ",
+        "release": "E39",
+        "sid": "015",
+        "image": "https://ws-tcg.com/wordpress/wp-content/images/cardlist/l/lnj_we39/lnj_we39_015.png"
+    },
+    {
+        "name": "ランジュの虜になりなさい？ 鐘 嵐珠",
+        "code": "LNJ/WE39-023",
+        "rarity": "N",
+        "expansion": "Love Live! Sukufesu 10th Anniversary",
+        "side": "W",
+        "type": "Character",
+        "color": "RED",
+        "level": 0,
+        "cost": 0,
+        "power": 1000,
+        "trigger": [],
+        "flavor_text": "",
+        "ability": [
+            "[A] - When this card is placed onto stage from hand, look at up to 2 cards from the top of your deck and place them back in any order.",
+            "[A] - At the beginning of your opponent's draw phase, reveal the top card of your deck. If that card is level 1 or higher, you may place this card into your stock. (Climaxes are regarded as level 0.)"
+        ],
+        "jpAbility": [
+            "【自】 このカードが手札から舞台に置かれた時、あなたは自分の山札を上から2枚まで見て、山札の上に好きな順番で置く。",
+            "【自】 相手のドローフェイズの始めに、あなたは自分の山札の上から1枚を公開する。そのカードのレベルが1以上なら、あなたはこのカードをストック置場に置いてよい。（クライマックスのレベルは0として扱う。公開したカードは元に戻す）"
+        ],
+        "attributes": [
+            "Music"
+        ],
+        "set": "LNJ",
+        "release": "E39",
+        "sid": "023",
+        "image": "https://ws-tcg.com/wordpress/wp-content/images/cardlist/l/lnj_we39/lnj_we39_023.png"
+    },
+    {
+        "name": "“ランジュがしたいこと”鐘 嵐珠",
+        "code": "LNJ/WE39-027",
+        "rarity": "N",
+        "expansion": "Love Live! Sukufesu 10th Anniversary",
+        "side": "W",
+        "type": "Character",
+        "color": "RED",
+        "level": 0,
+        "cost": 0,
+        "power": 2000,
+        "trigger": [],
+        "flavor_text": "",
+        "ability": [
+            "[C] - If you have no other characters in your front row, then this card gets +1500 power.",
+            "[A] - At the beginning of your opponent's attack phase, you may move this card to a slot in front row with no characters on it."
+        ],
+        "jpAbility": [
+            "【永】 他のあなたの前列のキャラがいないなら、このカードのパワーを＋1500。",
+            "【自】 相手のアタックフェイズの始めに、あなたはこのカードを前列の中央のキャラのいない枠に動かしてよい。"
+        ],
+        "attributes": [
+            "Music"
+        ],
+        "set": "LNJ",
+        "release": "E39",
+        "sid": "027",
+        "image": "https://ws-tcg.com/wordpress/wp-content/images/cardlist/l/lnj_we39/lnj_we39_027.png"
+    },
+    {
+        "name": "“お祝いは大歓迎”ミア・テイラー",
+        "code": "LNJ/WE39-043",
+        "rarity": "N",
+        "expansion": "Love Live! Sukufesu 10th Anniversary",
+        "side": "W",
+        "type": "Character",
+        "color": "BLUE",
+        "level": 0,
+        "cost": 0,
+        "power": 500,
+        "trigger": [],
+        "flavor_text": "",
+        "ability": [
+            "[A] - At the beginning of your climax phase, choose one of your characters and they get +500 power until end of turn.",
+            "[A] - BRAINSTORM [(1) REST this card] Flip the top four cards of your Deck, send them to Waiting Room. For each Climax among them, perform the following: Draw up to 2 cards, then choose one card in your hand and place it into waiting room."
+        ],
+        "jpAbility": [
+            "【自】 あなたのクライマックスフェイズの始めに、あなたは自分の《音楽》のキャラを1枚選び、そのターン中、パワーを＋500。",
+            "【起】 集中 ［(1) このカードを【レスト】する］ あなたは自分の山札の上から4枚をめくり、控え室に置く。それらのカードのクライマックス1枚につき、次の行動を行う。『あなたは2枚まで引き、自分の手札を1枚選び、控え室に置く。』"
+        ],
+        "attributes": [
+            "Music"
+        ],
+        "set": "LNJ",
+        "release": "E39",
+        "sid": "043",
+        "image": "https://ws-tcg.com/wordpress/wp-content/images/cardlist/l/lnj_we39/lnj_we39_043.png"
+    },
+    {
+        "name": "ボクから目を離さないでよね ミア・テイラー",
+        "code": "LNJ/WE39-049",
+        "rarity": "N",
+        "expansion": "Love Live! Sukufesu 10th Anniversary",
+        "side": "W",
+        "type": "Character",
+        "color": "BLUE",
+        "level": 0,
+        "cost": 0,
+        "power": 2000,
+        "trigger": [],
+        "flavor_text": "",
+        "ability": [
+            "[A] - This ability activates up to 2 times per turn. When another《Music》is placed onto stage from your hand, this card gets +1000 power until end of turn.",
+            "[A] - [(1)] When your other《Music》character is being frontal-attacked, you may pay the cost. If you do, return that character to your hand."
+        ],
+        "jpAbility": [
+            "【自】 この能力は1ターンにつき2回まで発動する。他のあなたの《音楽》のキャラが手札から舞台に置かれた時、そのターン中、このカードのパワーを＋1000。",
+            "【自】［(1) このカードを控え室に置く］ 他のあなたの《音楽》のキャラがフロントアタックされた時、あなたはコストを払ってよい。そうしたら、そのキャラを手札に戻す。"
+        ],
+        "attributes": [
+            "Music"
+        ],
+        "set": "LNJ",
+        "release": "E39",
+        "sid": "049",
+        "image": "https://ws-tcg.com/wordpress/wp-content/images/cardlist/l/lnj_we39/lnj_we39_049.png"
+    }
+]


### PR DESCRIPTION
Added 6 of the new cards from the Love Live! 10th Anniversary Premium Booster.

Reprints of existing cards have not been added. May consider to add them later.

May need to be checked before deploying onto main site.