### PR TITLE
OVL repeating text attempted bugfix.

### DIFF
--- a/DB/HBR_W103.json
+++ b/DB/HBR_W103.json
@@ -664,7 +664,7 @@
         "flavor_text": "",
         "ability": [
             "[C] – For each of your other《Seraph》Characters, this card gains +500 Power.",
-            "[A] – When this card attacks, if the Character across from this is Level 2 or lower, during this turn, this card gains +6000 Power."
+            "[A] – When this card attacks, if the Character across from this is Level 2, during this turn, this card gains +6000 Power."
         ],
         "jpAbility": [
             "【永】 他のあなたの《セラフ》のキャラ1枚につき、このカードのパワーを＋500。",

--- a/DB/OVL_S99.json
+++ b/DB/OVL_S99.json
@@ -2145,10 +2145,8 @@
         "flavor_text": "",
         "ability": [
             "COUNTER If you do not have [主へと捧ぐ愛 アルベド], you cannot play this card from Hand.",
-            "If your Level is 2, choose one of your《Heteromorphic》or《Nazarick》Characters, during this turn, it gains +1500 Power and the following effect:",
-            "-[C] - The Character across from this card gets -3 Soul.",
-            "[(1)] If your Level is 3, you may pay the cost. If you did, choose one of your《Heteromorphic》or《Nazarick》Characters, during this turn, it gains the following effect:",
-            "-[C] - The Character across from this card gets -3 Soul."
+            "If your Level is 2, choose one of your《Heteromorphic》or《Nazarick》Characters, during this turn, it gains +1500 Power and the following effect:-[C] - The Character across from this card gets -3 Soul.",
+            "[(1)] If your Level is 3, you may pay the cost. If you did, choose one of your《Heteromorphic》or《Nazarick》Characters, during this turn, it gains the following effect: -[C] - The Character across from this card gets -3 Soul."
         ],
         "jpAbility": [
             "【カウンター】 このカードは、あなたの「主へと捧ぐ愛 アルベド」がいないなら、手札からプレイできない。",


### PR DESCRIPTION
![image](https://github.com/CCondeluci/WeissSchwarz-JP-DB/assets/54648764/448e60a0-7e4a-4f43-ae71-6739176c6c71)

Not guaranteed to fix the issue, but tried reformating the card to see if it fixes the issue. Maybe has to do with the duplicate text appearing, but will need to pushed to main site to see.